### PR TITLE
Upgrade to Netty 4.1.59.Final and netty-tcnative 2.0.36.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <properties>
     <stack.version>4.0.3-SNAPSHOT</stack.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.59.Final</netty.version>
     <jackson.version>2.11.3</jackson.version>
-    <tcnative.version>2.0.34.Final</tcnative.version>
+    <tcnative.version>2.0.36.Final</tcnative.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Hi

Package Owner: Abhishek kumar nishant

PR change Details:
$Patch Details : Following file has been modified:

.pom.xml:
Modified pom.xml to update netty-tcnative-boringssl-static version '2.0.34.final' to '2.0.36.final'.

$Testing Detail:

After doing the changes,verified working by executing 'mvn install' command and is building fine on x86 and aarch64 both platforms.

**$PR Description :Here is my commit message :**

Upgrade netty-tcnative-boringssl-static to 2.0.36.Final

**Body**

As v2.0.34 of Netty-tcnative-boringssl-static’s is having a naming convention issue in aarch64 specific released jars, (which caught in test-cases errors in package ‘Vert.X Core’), so updated this to latest v2.0.36.Final.

Signed-off-by: odidev odidev@puresoftware.com

$ Reviewer: Shobhit Parashari
